### PR TITLE
#158 Add GitHub Issue Template markdown

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+This repository's issues are reserved for feature requests and bug reports.
+
+* **I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+
+
+* **What is the current behavior?**
+
+
+
+* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem**
+
+```
+// here
+```
+
+* **What is the expected behavior?**
+
+
+* **What is the motivation / use case for changing the behavior?**
+
+
+* **Please tell us about your environment:**
+  
+  - [ ] Windows
+  - [ ] MacOS
+  - [ ] Linux
+
+
+* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)


### PR DESCRIPTION
Adapted from https://github.com/stevemao/github-issue-templates (CC 0 Public Domain).

Changes? Happy to squash.