### PR TITLE
ui: Add a tooltip component

### DIFF
--- a/src/renderer/components/common/tooltip.jsx
+++ b/src/renderer/components/common/tooltip.jsx
@@ -1,0 +1,16 @@
+import React, { PureComponent } from 'react'
+
+class Tooltip extends PureComponent {
+  render() {
+    const { children, tip, name } = this.props
+    return (
+      <div class="tooltip">
+        <span>{children}</span>
+        <span id={name} class="tooltiptext">
+          {tip}
+        </span>
+      </div>
+    )
+  }
+}
+export default Tooltip

--- a/src/renderer/components/player/view.jsx
+++ b/src/renderer/components/player/view.jsx
@@ -6,6 +6,7 @@ import Icon from '@mdi/react'
 import * as icons from '@/constants/icons'
 import classnames from 'classnames'
 import Slider from './slider'
+import Tooltip from '@/components/common/tooltip'
 
 const formatTime = (seconds = 0) => moment.utc(seconds * 1000).format('mm:ss')
 
@@ -13,11 +14,13 @@ const formatTime = (seconds = 0) => moment.utc(seconds * 1000).format('mm:ss')
 import '@/css/slider.css'
 import css from '@/css/modules/player.css.module'
 
-const ControlButton = ({ icon, action, size, disabled }) => {
+const ControlButton = ({ icon, action, size, disabled, tip }) => {
   return (
-    <button className={css.button} onClick={action} disabled={disabled}>
-      <Icon path={icon} className={`icon icon--${size || 'large'}`} />
-    </button>
+    <Tooltip tip={tip}>
+      <button className={css.button} onClick={action} disabled={disabled}>
+        <Icon path={icon} className={`icon icon--${size || 'large'}`} />
+      </button>
+    </Tooltip>
   )
 }
 
@@ -232,17 +235,20 @@ class Player extends React.PureComponent {
         icon: icons.SKIP_PREVIOUS,
         action: () => {},
         disabled: true,
+        tip: 'Skip',
       },
       {
         size: 'large-x',
         icon: paused ? icons.PLAY : icons.PAUSE,
         action: () => togglePlay(),
         disabled: !ready,
+        tip: 'Play',
       },
       {
         icon: icons.SKIP_NEXT,
         action: () => {},
         disabled: true,
+        tip: 'Next',
       },
     ]
 
@@ -251,16 +257,19 @@ class Player extends React.PureComponent {
         icon: icons.SHUFFLE,
         action: () => {},
         disabled: true,
+        tip: 'Shuffle',
       },
       {
         icon: icons.REPEAT,
         action: () => {},
         disabled: true,
+        tip: 'Repeat',
       },
       {
         icon: icons.HEART_OUTLINE,
         action: () => {},
         disabled: true,
+        tip: 'Favorite',
       },
     ]
 

--- a/src/renderer/css/component/tooltip.css
+++ b/src/renderer/css/component/tooltip.css
@@ -1,0 +1,45 @@
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -60px;
+
+  opacity: 0;
+  display: none;
+  transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.tooltip .tooltiptext::disabled {
+  display: none;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+  display: block;
+}

--- a/src/renderer/css/index.css
+++ b/src/renderer/css/index.css
@@ -9,6 +9,7 @@
 @import url('./component/header.css');
 @import url('./component/button.css');
 @import url('./component/sidebar.css');
+@import url('./component/tooltip.css');
 @import url('./component/track-list.css');
 @import url('./component/empty-state.css');
 


### PR DESCRIPTION
Add a tooltip component.

Resolving issue #183 

Display a tooltip on buttons' hovering.

Tested on media control bar.
Operating System: macOS
