### PR TITLE
Add tooltip component

### DIFF
--- a/src/renderer/components/tooltip/view.jsx
+++ b/src/renderer/components/tooltip/view.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 class Tooltip extends React.PureComponent {
   render() {
-    const { text, placement = 'top', children } = this.props
+    const { text, placement, children } = this.props
 
     return (
       <div className="tooltip">
@@ -11,6 +11,10 @@ class Tooltip extends React.PureComponent {
       </div>
     )
   }
+}
+
+Tooltip.defaultProps = {
+  placement: 'top',
 }
 
 export default Tooltip

--- a/src/renderer/components/tooltip/view.jsx
+++ b/src/renderer/components/tooltip/view.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+class Tooltip extends React.PureComponent {
+  render() {
+    const { text, placement = 'top', children } = this.props
+
+    return (
+      <div className="tooltip">
+        <span className={`tooltip-text tooltip-${placement}`}>{text}</span>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default Tooltip

--- a/src/renderer/css/component/tooltip.css
+++ b/src/renderer/css/component/tooltip.css
@@ -1,0 +1,79 @@
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltip-text {
+  visibility: hidden;
+  position: absolute;
+  width: 120px;
+  background-color: #3f3f43;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+.tooltip-text::after {
+  content: '';
+  position: absolute;
+  border-width: 5px;
+  border-style: solid;
+}
+
+.tooltip-left {
+  bottom: auto;
+  right: 128%;
+}
+
+.tooltip-left::after {
+  top: 50%;
+  left: 100%;
+  margin-top: -5px;
+  border-color: transparent transparent transparent #3f3f43;
+}
+
+.tooltip-bottom {
+  top: 135%;
+  left: 50%;
+  margin-left: -60px;
+}
+
+.tooltip-bottom::after {
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-color: transparent transparent #3f3f43 transparent;
+}
+
+.tooltip-top {
+  bottom: 125%;
+  left: 50%;
+  margin-left: -60px;
+}
+
+.tooltip-top::after {
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-color: #3f3f43 transparent transparent transparent;
+}
+
+.tooltip-right {
+  left: 125%;
+}
+
+.tooltip-right::after {
+  top: 50%;
+  right: 100%;
+  margin-top: -5px;
+  border-color: transparent #3f3f43 transparent transparent;
+}

--- a/src/renderer/css/component/tooltip.css
+++ b/src/renderer/css/component/tooltip.css
@@ -4,7 +4,6 @@
 }
 
 .tooltip .tooltip-text {
-  visibility: hidden;
   position: absolute;
   width: 120px;
   background-color: #3f3f43;
@@ -13,13 +12,12 @@
   padding: 5px 0;
   border-radius: 6px;
   z-index: 1;
-  opacity: 0;
   transition: opacity 0.3s;
+  display: none;
 }
 
 .tooltip:hover .tooltip-text {
-  visibility: visible;
-  opacity: 1;
+  display: block;
 }
 
 .tooltip-text::after {

--- a/src/renderer/css/index.css
+++ b/src/renderer/css/index.css
@@ -11,6 +11,7 @@
 @import url('./component/sidebar.css');
 @import url('./component/track-list.css');
 @import url('./component/empty-state.css');
+@import url('./component/tooltip.css');
 
 html {
   background: black;


### PR DESCRIPTION
**What kind of change does this PR introduce? Explain your changes. (Bug fix, feature, docs update, ...)**

* Adds a tooltip component


**Does this close any currently open issues?**

* Solves #183 issue

**What is the new behavior (if this is a feature change)?**

You can wrap an element with a Tooltip component to make a tooltip appear on the element.
You can provide props:
* text - specifies the text that tooltip displays
* placement - specifies where the toltip should be placed (default = 'top')

```
<Tooltip text='I'm a tooltip' placement='bottom'>
  <Button></Button>
<Tooltip />
```

**Where has this been tested?**

  * Operating System: windows
  * Sidebar and player components

