### PR TITLE
Updated link for LBRY Daemon download/install to be more direct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,31 @@
 <img src="https://user-images.githubusercontent.com/39308480/43605302-e794780c-9665-11e8-9e25-7abefc7a3092.png" alt="jelly-beats" width="54%">
 
- [![David](https://img.shields.io/david/btzr-io/jelly-beats.svg?style=flat-square)](https://david-dm.org/btzr-io/jelly-beats)
- [![GitHub license](https://img.shields.io/github/license/btzr-io/jelly-beats.svg?style=flat-square)](https://github.com/btzr-io/electron-preact-app/blob/master/LICENSE)
- 
+[![David](https://img.shields.io/david/btzr-io/jelly-beats.svg?style=flat-square)](https://david-dm.org/btzr-io/jelly-beats)
+[![GitHub license](https://img.shields.io/github/license/btzr-io/jelly-beats.svg?style=flat-square)](https://github.com/btzr-io/electron-preact-app/blob/master/LICENSE)
 
 ## What's this?
 
 A Decentralized music streaming platform.
 
-
 ## The lbry protocol
 
 [LBRY](https://github.com/lbryio/lbry) is an open-source protocol providing distribution, discovery, and purchase of digital content via a decentralized network. We use this protocol to discover and stream music and other audio files such as podcasts.
 
-
 ## Dependencies required
 
 In order to run this app you need to install all these dependencies:
+
 - [Git](https://git-scm.com/)
-- [Node.js LTS](https://nodejs.org/) 
+- [Node.js LTS](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com/)
-- [LBRY Daemon](https://github.com/lbryio/lbry)
+- [LBRY Daemon](https://lbry.io/quickstart/install)
 
-
- > **Only for Linux**
- >
- > You may also require make tools. For example, on Debian you can install [Build-essentials](https://packages.debian.org/stretch/build-essential) package.
-
+> **Only for Linux**
+>
+> You may also require make tools. For example, on Debian you can install [Build-essentials](https://packages.debian.org/stretch/build-essential) package.
 
 ## How to run
+
 ```sh
 # Clone this repository
 $ git clone https://github.com/btzr-io/jelly-beats.git
@@ -42,6 +39,7 @@ $ yarn dev
 ```
 
 ## How to package
+
 ```sh
 # Run the app
 $ yarn dist


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

* **What kind of change does this PR introduce? Explain your changes. (Bug fix, feature, docs update, ...)**

I introduced a (really) small update to the README.

* **Does this close any currently open issues?**

Re: #166, this does not close the issue; it's just a small effort toward 'resolving' the issue by improving the readme.


* **What is the new behavior (if this is a feature change)?**

This updates the link to download/install the LBRY Daemon needed to run the project locally. I spent a few minutes looking around for the daemon with the current link, and this page provided a direct download of the daemon, as well as a link to instructions to install it from source if someone prefers. I believe it will allow new contributors to get the LBRY Daemon dependency with less hassle in order to start hacking away more easily. 😃 


* **Where has this been tested?**

    * Operating System: Windows 10 Pro, but OS is irrelevant in this case.
