### PR TITLE
Shows player when track starts being played.

### DIFF
--- a/src/renderer/components/app/index.js
+++ b/src/renderer/components/app/index.js
@@ -2,4 +2,4 @@ import React from 'react'
 import { connect } from 'unistore/react'
 import App from './view'
 
-export default connect('navigation')(App)
+export default connect('navigation, player')(App)

--- a/src/renderer/components/app/view.jsx
+++ b/src/renderer/components/app/view.jsx
@@ -29,12 +29,12 @@ class App extends React.PureComponent {
 
   render() {
     const { children, player } = this.props
-    const currentTrack = player && player.currentTrack
+    const { showPlayer } = player || {}
 
     return (
       <React.Fragment>
         <Header />
-        <div id="window">
+        <div id="window" className={showPlayer ? 'short' : ''}>
           <SideBar />
           <Router routes={routes} defaultRoute={'/'} />
           <Player />

--- a/src/renderer/components/player/view.jsx
+++ b/src/renderer/components/player/view.jsx
@@ -127,7 +127,7 @@ class Player extends React.PureComponent {
     // ready to play
     console.info('New track loaded!')
     this.setState({ ready: true })
-    updatePlayerStatus({ isLoading: false })
+    updatePlayerStatus({ isLoading: false, showPlayer: true })
     this.play()
   }
 
@@ -219,7 +219,7 @@ class Player extends React.PureComponent {
   render() {
     const { ready, currentTime } = this.state
     const { player, downloads, togglePlay } = this.props
-    const { paused, syncPaused, currentTrack } = player || {}
+    const { paused, syncPaused, currentTrack, showPlayer } = player || {}
     const { uri, title, artist, thumbnail } = currentTrack || {}
 
     const playerOptions = {
@@ -268,7 +268,7 @@ class Player extends React.PureComponent {
     const { duration, isDownloading } = fileSource
 
     return (
-      <div className={css.player + ' ' + css.active}>
+      <div className={css.player + ' ' + (showPlayer ? css.active : '')}>
         <audio ref={this.audioElement} {...playerOptions} />
 
         <div className={css.container}>

--- a/src/renderer/css/index.css
+++ b/src/renderer/css/index.css
@@ -67,11 +67,16 @@ a {
   top: var(--header-height);
   left: 0;
   right: 0;
-  bottom: var(--player-height);
+  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   z-index: 0;
+  transition: bottom 300ms ease;
+}
+
+#window.short {
+  bottom: var(--player-height);
 }
 
 .view {

--- a/src/renderer/unistore/initialState.js
+++ b/src/renderer/unistore/initialState.js
@@ -9,6 +9,7 @@ initialState.navigation = {
 initialState.player = {
   paused: true,
   isLoading: false,
+  showPlayer: false,
   syncPaused: true,
   currentTrack: {},
 }


### PR DESCRIPTION
Closes #186. It's a feature.

The player is hidden by default, only when a track is played the player is shown. It's done with a new property (showPlayer) in order to allow hide it adding a new button to the player component (for example). In any case, showing/hiding the player component is unrelated with playing the song, so it's more flexible.


* **Where has this been tested?**

    * Operating System: macOs
