### PR TITLE
Made Card component responsive

### DIFF
--- a/src/renderer/css/modules/card.css.module
+++ b/src/renderer/css/modules/card.css.module
@@ -1,7 +1,8 @@
 .card {
-  width: 184px;
+  width: 46%;
+  max-width: 13em;
   display: inline-block;
-  margin: 16px;
+  padding: 2%;
   text-align: left;
   vertical-align: top;
   overflow: hidden;
@@ -87,4 +88,24 @@
   justify-content: flex-start;
   align-items: center;
   flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+   .card {
+    width: 29.3%;
+  }
+}
+
+@media (min-width: 1000px) {
+   .card {
+    width: 22%;
+    padding: 0.6em;
+  }
+}
+
+@media (min-width: 1200px) {
+   .card {
+    width: 14.5%;
+    padding: 0.6em;
+  }
 }

--- a/src/renderer/css/modules/thumbnail.css.module
+++ b/src/renderer/css/modules/thumbnail.css.module
@@ -1,16 +1,19 @@
 .thumb {
-  height: 184px;
-  width: 100%;
+  padding-top: 100%;
+  height: auto;
+  width: auto;
   overflow: hidden;
   position: relative;
   margin: 0;
   opacity: 0;
+
   transition: opacity 0.3s ease 0.3s;
 }
 
 .thumb img,
 .thumbReady img {
   display: none;
+  width: 100%;
 }
 
 .thumbReady {
@@ -19,6 +22,8 @@
 }
 
 .picture {
+  position: absolute;
+  top: 0;
   height: 100%;
   width: 100%;
   background-color: rgba(0, 0, 0, 0.2);
@@ -55,3 +60,5 @@
   bottom: 0;
   left: 0;
 }
+
+


### PR DESCRIPTION

* **What kind of change does this PR introduce?**

  Makes the Card component responsive.
Would recommend setting a min-width to the '.grid' div so the layout won't look broken if the window is too small. Also, a 'justify-content: center' for when the max window width is reached.

  ![](https://media.giphy.com/media/X8W7jAkkfkDGgnLIz3/giphy.gif)

* **Does this close any currently open issues?**

  Issue #194

* **What is the new behavior (if this is a feature change)?**

  Cards resize and rearrange according to window width.

* **Where has this been tested?**
    * Operating System: macOS Mojave Version 10.14